### PR TITLE
Configure project for java 8 compatibility and fix javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.efluid.oss</groupId>
@@ -41,8 +42,8 @@
   </scm>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -138,6 +139,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9.1</version>
+        <configuration>
+          <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+          <source>8</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/com/efluid/tcbc/ScanneClasspath.java
+++ b/src/main/java/com/efluid/tcbc/ScanneClasspath.java
@@ -116,6 +116,8 @@ public abstract class ScanneClasspath {
 
   /**
    * Aucune erreur ne doit être remontée
+   *
+   * @param erreurs Nombre d’erreur
    */
   protected void isValid(int erreurs) {
     assertThat(0).isEqualTo(erreurs);
@@ -214,7 +216,7 @@ public abstract class ScanneClasspath {
    */
   private List<Path> getFichiersClass(String repertoireClasses) throws IOException {
     final List<Path> fichiersClass = new ArrayList<>();
-    Files.walkFileTree(Paths.get(repertoireClasses), new SimpleFileVisitor<>() {
+    Files.walkFileTree(Paths.get(repertoireClasses), new SimpleFileVisitor<Path>() {
 
       @Override
       public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {
@@ -255,6 +257,9 @@ public abstract class ScanneClasspath {
 
   /**
    * Filtre permettant de ne parcourir que les jars souhaités
+   *
+   * @param pathJar Chemin du jar a tester
+   * @return true si le jar est présent
    */
   protected boolean isJarInclu(String pathJar) {
     return jarsInclus.stream().anyMatch(jar -> pathJar.contains(File.separatorChar + jar));


### PR DESCRIPTION
Just change target and source version for java 8. This allow the project to be used in java 8 and highter project (11, 12, ...)

refs #8 

Fix the javadoc to build and fix warnings