### PR TITLE
feat: Add a empty folder check in getFichiersClass

### DIFF
--- a/src/main/java/com/efluid/tcbc/process/ScanneClasspath.java
+++ b/src/main/java/com/efluid/tcbc/process/ScanneClasspath.java
@@ -237,7 +237,11 @@ public abstract class ScanneClasspath {
    */
   private List<Path> getFichiersClass(String repertoireClasses) throws IOException {
     final List<Path> fichiersClass = new ArrayList<>();
-    Files.walkFileTree(Paths.get(repertoireClasses), new SimpleFileVisitor<Path>() {
+    Path repertoireClassesPath = Paths.get(repertoireClasses);
+    if (Files.notExists(repertoireClassesPath)) {
+      return fichiersClass;
+    }
+    Files.walkFileTree(repertoireClassesPath, new SimpleFileVisitor<Path>() {
 
       @Override
       public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) {


### PR DESCRIPTION
Add a check in order to avoid printing error log when we run the test in a project with no source code.
For example, if you create a new maven module, with testControlByteCode as dependency, and add just a test classes, you will have this error when running `mvn test` : 
```
java.nio.file.NoSuchFileException: /..../sous-module-test-byte-code/target/classes
``` 