### PR TITLE
[fix] Modify the directory /opt/mvnDockerDefault/conf/gpg to /tmp for the plugin maven maven-gpg-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
               </execution>
             </executions>
             <configuration>
-              <homedir>/opt/mvnDockerDefault/conf/gpg</homedir>
+              <homedir>/tmp</homedir>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Modify the directory /opt/mvnDockerDefault/conf/gpg to /tmp for the plugin maven maven-gpg-plugin