### PR TITLE
[feat] JUnit 5 migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.3</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/efluid/tcbc/TestControleByteCode.java
+++ b/src/main/java/com/efluid/tcbc/TestControleByteCode.java
@@ -63,7 +63,7 @@ public class TestControleByteCode extends ScanneClasspath {
    * Possibilité de configurer le nombre de jar minimum traité via la variable d'environnement -DnbJarMinimum=2
    */
   private void validerNombreJarMinimumTraite() {
-    assertThat(getJarsTraites().size() > nbJarMinimum).isTrue();
+    assertThat(getJarsTraites().size()).isGreaterThan(nbJarMinimum);
   }
 
   @Override

--- a/src/main/java/com/efluid/tcbc/process/ScanneClasspath.java
+++ b/src/main/java/com/efluid/tcbc/process/ScanneClasspath.java
@@ -1,9 +1,9 @@
 package com.efluid.tcbc.process;
 
-import static java.io.File.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static java.io.File.separator;
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.Files.*;
-import static org.assertj.core.api.Assertions.assertThat;
 import static com.efluid.tcbc.process.ScanneClasspath.Exclusion.*;
 
 import java.io.File;
@@ -28,8 +28,8 @@ import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 
 import org.assertj.core.util.VisibleForTesting;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -135,7 +135,7 @@ public abstract class ScanneClasspath {
     doLogList(exclusions.get(ERREUR), "Exclusions des erreurs");
   }
 
-  @Before
+  @BeforeEach
   public void init() {
     chargerConfiguration();
   }

--- a/src/test/java/com/efluid/example/TestExampleControlByteCode.java
+++ b/src/test/java/com/efluid/example/TestExampleControlByteCode.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.*;
 import java.util.NoSuchElementException;
 
+import org.junit.jupiter.api.BeforeEach;
+
 import com.efluid.tcbc.TestControleByteCode;
 import com.efluid.tcbc.object.*;
 import net.bytebuddy.ByteBuddy;
@@ -20,6 +22,7 @@ public class TestExampleControlByteCode extends TestControleByteCode {
   private static final String TARGET_TEST_CLASSES = "target/test-classes";
 
   @Override
+  @BeforeEach
   public void init() {
     super.init();
     changeTheReturnTypeFromStringToVoid();

--- a/src/test/java/com/efluid/example/TestExampleDependenceJar.java
+++ b/src/test/java/com/efluid/example/TestExampleDependenceJar.java
@@ -46,7 +46,7 @@ public class TestExampleDependenceJar extends TestDependenceJar {
 
   @Override
   protected void isValid(int erreurs) {
-    assertThat(erreurs).isEqualTo(0);
+    assertThat(erreurs).isZero();
     Jar jarTestClasses = getJarsTraites().stream().filter(jar -> jar.getNom().contains("test-classes")).findFirst().get();
     assertThat(jarTestClasses.getDependences()).hasKeySatisfying(new Condition<>(k -> k.contains("slf4j"), "No dependence with sfl4j"));
     assertThat(new File(NOM_FICHIER_GRAPHVIZ)).isFile().exists();

--- a/src/test/java/com/efluid/example/TestExampleFichiersEnDoublons.java
+++ b/src/test/java/com/efluid/example/TestExampleFichiersEnDoublons.java
@@ -2,7 +2,7 @@ package com.efluid.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 import com.efluid.tcbc.TestControleFichiersEnDoublon;
 
@@ -10,8 +10,8 @@ public class TestExampleFichiersEnDoublons extends TestControleFichiersEnDoublon
 
   @Override
   protected void isValid(int erreurs) {
-    assertThat(2).isEqualTo(erreurs);
-    assertThat(fichiersEnDoublon.get(Ignore.class.getName() + ".class")).isNotNull();
+    assertThat(erreurs).isEqualTo(2);
+    assertThat(fichiersEnDoublon.get(Disabled.class.getName() + ".class")).isNotNull();
     assertThat(fichiersEnDoublon.get("META-INF.maven.commons-cli.commons-cli.pom.properties")).isNotNull();
   }
 }

--- a/src/test/java/com/efluid/tcbc/process/ScanneClasspathTest.java
+++ b/src/test/java/com/efluid/tcbc/process/ScanneClasspathTest.java
@@ -7,26 +7,27 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.junit.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ScanneClasspathTest {
+class ScanneClasspathTest {
 
   private ScanneClasspath tested;
 
-  @Before
-  public void init() {
+  @BeforeEach
+  void init() {
     tested = spy(ScanneClasspath.class);
   }
 
   @Test
-  public void should_return_empty_list_on_get_fichiers_class() throws IOException {
+  void should_return_empty_list_on_get_fichiers_class() throws IOException {
     String pathThatExist = "";
     String pathThatDoesNotExist = "Path/that/does/not/exist";
 
     List<Path> shoudlNotBeEmpty = tested.getFichiers(pathThatExist);
-    assertThat(shoudlNotBeEmpty.isEmpty()).isFalse();
+    assertThat(shoudlNotBeEmpty).isNotEmpty();
 
     List<Path> shoudlBeEmpty = tested.getFichiers(pathThatDoesNotExist);
-    assertThat(shoudlBeEmpty.isEmpty()).isTrue();
+    assertThat(shoudlBeEmpty).isEmpty();
   }
 }

--- a/src/test/java/org/junit/jupiter/api/Disabled.java
+++ b/src/test/java/org/junit/jupiter/api/Disabled.java
@@ -1,8 +1,8 @@
-package org.junit;
+package org.junit.jupiter.api;
 
 import com.efluid.example.TestExampleFichiersEnDoublons;
 
 /** Use for a test of a classe in doublon {@link TestExampleFichiersEnDoublons} */
-public @interface Ignore {
+public @interface Disabled {
   String value();
 }


### PR DESCRIPTION
 - remove all JUnit 4 usage
 - migrate everything in JUnit 5
 - replace `Ignore` class by `Disable` for `TestExampleFichiersEnDoublons`